### PR TITLE
Remove logging config call from Socketcluster.py

### DIFF
--- a/socketclusterclient/Socketcluster.py
+++ b/socketclusterclient/Socketcluster.py
@@ -7,9 +7,6 @@ import importlib
 Emitter = importlib.import_module(".Emitter", package="socketclusterclient")
 Parser = importlib.import_module(".Parser", package="socketclusterclient")
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
-
-
 class socket(Emitter.emitter):
     def emitack(self, event, object, ack):
         emitobject = json.loads('{}')


### PR DESCRIPTION
Logging configuration should be left to user code. Specifying it here can clobber user attempts at using their own formats. Consider the following sessions, which differ only by an import statement:

```
>>> import logging
>>> 
>>> logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s')
>>> 
>>> logging.error('This should have a timestamp...')
2017-12-22 16:51:07,623 ERROR: This should have a timestamp...
```

versus

```
>>> import logging
>>> from socketclusterclient import Socketcluster
>>> 
>>> logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s')
>>> 
>>> logging.error('This should have a timestamp...')
ERROR:This should have a timestamp...
```


